### PR TITLE
Add tile menu to home page and top level sections

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,7 @@
     { "language": "javascriptreact", "autoFix": true },
     { "language": "typescript", "autoFix": true },
     { "language": "typescriptreact", "autoFix": true }
-  ]
+  ],
+  "typescript.suggest.autoImports": false,
+  "javascript.suggest.autoImports": false
 }

--- a/docs/rules/01-naming/README.md
+++ b/docs/rules/01-naming/README.md
@@ -12,6 +12,8 @@ We could refer to [Eye Tracking's](http://www.cs.kent.edu/~jmaletic/papers/ICPC2
 
 In the absence of conclusive research, we suggest to follow the rules: Давайте будем разбираться в каждом конкретном случае.
 
+<!-- card-links -->
+
 - [1.1. Use `camelCase` for GraphQL fields and arguments.](./naming-fields-args.md)
 - [1.2. Use `UpperCamelCase` for GraphQL types.](./naming-types.md)
 - [1.3. Use `CAPITALIZED_WITH_UNDERSCORES` to name ENUM types.](./naming-enum.md)

--- a/docs/rules/01-naming/README.md
+++ b/docs/rules/01-naming/README.md
@@ -1,4 +1,5 @@
 ---
+pageType: section
 path: '/rules/naming'
 title: '1. Naming rules'
 ---
@@ -11,7 +12,6 @@ We could refer to [Eye Tracking's](http://www.cs.kent.edu/~jmaletic/papers/ICPC2
 
 In the absence of conclusive research, we suggest to follow the rules: Давайте будем разбираться в каждом конкретном случае.
 
-- **1. Naming rules**
-  - [1.1. Use `camelCase` for GraphQL fields and arguments.](./naming-fields-args.md)
-  - [1.2. Use `UpperCamelCase` for GraphQL types.](./naming-types.md)
-  - [1.3. Use `CAPITALIZED_WITH_UNDERSCORES` to name ENUM types.](./naming-enum.md)
+- [1.1. Use `camelCase` for GraphQL fields and arguments.](./naming-fields-args.md)
+- [1.2. Use `UpperCamelCase` for GraphQL types.](./naming-types.md)
+- [1.3. Use `CAPITALIZED_WITH_UNDERSCORES` to name ENUM types.](./naming-enum.md)

--- a/docs/rules/02-type/README.md
+++ b/docs/rules/02-type/README.md
@@ -1,4 +1,5 @@
 ---
+pageType: section
 path: '/rules/type'
 title: '2. Type rules'
 ---
@@ -9,6 +10,5 @@ However, when a scalar type is not representable in JSON by default (e.g. `Date`
 
 In such cases, GraphQL allows you to create your own custom scalar types. [This article](../types/README.md#custom-scalar-types) describes it.
 
-- **2. Type rules**
-  - [2.1. Use custom scalar types if you want to declare fields or args with specific semantic value.](./type-custom-scalars.md)
-  - [2.2. Use Enum for fields which contain a specific set of values.](./type-enumerable.md)
+- [2.1. Use custom scalar types if you want to declare fields or args with specific semantic value.](./type-custom-scalars.md)
+- [2.2. Use Enum for fields which contain a specific set of values.](./type-enumerable.md)

--- a/docs/rules/02-type/README.md
+++ b/docs/rules/02-type/README.md
@@ -10,5 +10,7 @@ However, when a scalar type is not representable in JSON by default (e.g. `Date`
 
 In such cases, GraphQL allows you to create your own custom scalar types. [This article](../types/README.md#custom-scalar-types) describes it.
 
+<!-- card-links -->
+
 - [2.1. Use custom scalar types if you want to declare fields or args with specific semantic value.](./type-custom-scalars.md)
 - [2.2. Use Enum for fields which contain a specific set of values.](./type-enumerable.md)

--- a/docs/rules/03-fields-output/README.md
+++ b/docs/rules/03-fields-output/README.md
@@ -1,11 +1,11 @@
 ---
+pageType: section
 path: '/rules/output'
 title: '3. Field Rules (Output)'
 ---
 
 In GraphQL fields are used to describe the shape of data that will be transferred from the server to the client. They may be described as scalar types as well as complex structures - Object type (GraphQLObjectType).
 
-- **3. Field Rules (Output)**
-  - [3.1. Use semantic names for fields and avoid leaking of implementation details in fields names.](./output-semantic-names.md)
-  - [3.2. Use `Non-Null` field if field will always have a given field value.](./output-non-null.md)
-  - [3.3. Group as many related fields into custom Object type as possible.](./output-grouping.md)
+- [3.1. Use semantic names for fields and avoid leaking of implementation details in fields names.](./output-semantic-names.md)
+- [3.2. Use `Non-Null` field if field will always have a given field value.](./output-non-null.md)
+- [3.3. Group as many related fields into custom Object type as possible.](./output-grouping.md)

--- a/docs/rules/03-fields-output/README.md
+++ b/docs/rules/03-fields-output/README.md
@@ -6,6 +6,8 @@ title: '3. Field Rules (Output)'
 
 In GraphQL fields are used to describe the shape of data that will be transferred from the server to the client. They may be described as scalar types as well as complex structures - Object type (GraphQLObjectType).
 
+<!-- card-links -->
+
 - [3.1. Use semantic names for fields and avoid leaking of implementation details in fields names.](./output-semantic-names.md)
 - [3.2. Use `Non-Null` field if field will always have a given field value.](./output-non-null.md)
 - [3.3. Group as many related fields into custom Object type as possible.](./output-grouping.md)

--- a/docs/rules/04-fields-input/README.md
+++ b/docs/rules/04-fields-input/README.md
@@ -1,9 +1,9 @@
 ---
+pageType: section
 path: '/rules/input'
 title: '4. Argument rules'
 ---
 
-- **4. Argument rules (Input)**
-  - [4.1. Group coupled arguments to the new input-type.](./input-grouping.md)
-  - [4.2. Use strict scalar types for arguments, eg. `DateTime` instead of `String`.](./input-custom-scalar.md)
-  - [4.3. Mark arguments as `required`, is they are required for query execution.](./input-non-null.md)
+- [4.1. Group coupled arguments to the new input-type.](./input-grouping.md)
+- [4.2. Use strict scalar types for arguments, eg. `DateTime` instead of `String`.](./input-custom-scalar.md)
+- [4.3. Mark arguments as `required`, is they are required for query execution.](./input-non-null.md)

--- a/docs/rules/04-fields-input/README.md
+++ b/docs/rules/04-fields-input/README.md
@@ -4,6 +4,8 @@ path: '/rules/input'
 title: '4. Argument rules'
 ---
 
+<!-- card-links -->
+
 - [4.1. Group coupled arguments to the new input-type.](./input-grouping.md)
 - [4.2. Use strict scalar types for arguments, eg. `DateTime` instead of `String`.](./input-custom-scalar.md)
 - [4.3. Mark arguments as `required`, is they are required for query execution.](./input-non-null.md)

--- a/docs/rules/05-list/README.md
+++ b/docs/rules/05-list/README.md
@@ -6,6 +6,8 @@ title: '5. Rules of lists'
 
 I never saw an API that does not return a list of items. Or it's page by page or something built on cursors for infinite lists. Lists should be filtered, sorted, and the number of returned items should be limited. GraphQL itself does not limit the freedom of implementation, but in order to form a certain uniformity, it is necessary to have a standard.
 
+<!-- card-links -->
+
 - [5.1. To filter the lists, use the `filter` argument, which contains all the available filters.](./list-filter.md)
 - [5.2. Use argument `sort` of type `Enum` or `[Enum!]` for listings sorting.](./list-sort.md)
 - [5.3. Use `limit` with default value and `skip` to limit number of returned items in list.](./list-limit-skip.md)

--- a/docs/rules/05-list/README.md
+++ b/docs/rules/05-list/README.md
@@ -1,13 +1,13 @@
 ---
+pageType: section
 path: '/rules/list'
 title: '5. Rules of lists'
 ---
 
 I never saw an API that does not return a list of items. Or it's page by page or something built on cursors for infinite lists. Lists should be filtered, sorted, and the number of returned items should be limited. GraphQL itself does not limit the freedom of implementation, but in order to form a certain uniformity, it is necessary to have a standard.
 
-- **5. Rules of lists**
-  - [5.1. To filter the lists, use the `filter` argument, which contains all the available filters.](./list-filter.md)
-  - [5.2. Use argument `sort` of type `Enum` or `[Enum!]` for listings sorting.](./list-sort.md)
-  - [5.3. Use `limit` with default value and `skip` to limit number of returned items in list.](./list-limit-skip.md)
-  - [5.4. Use `page`, `perPage` args for pagination and return output type with `items` (array of elements) and `pageInfo` (meta-data).](./list-pagination.md)
-  - [5.5. For infinite lists (infinite scroll) use `Relay Cursor Connections Specification`](./list-cursor-connection.md)
+- [5.1. To filter the lists, use the `filter` argument, which contains all the available filters.](./list-filter.md)
+- [5.2. Use argument `sort` of type `Enum` or `[Enum!]` for listings sorting.](./list-sort.md)
+- [5.3. Use `limit` with default value and `skip` to limit number of returned items in list.](./list-limit-skip.md)
+- [5.4. Use `page`, `perPage` args for pagination and return output type with `items` (array of elements) and `pageInfo` (meta-data).](./list-pagination.md)
+- [5.5. For infinite lists (infinite scroll) use `Relay Cursor Connections Specification`](./list-cursor-connection.md)

--- a/docs/rules/05-list/list-cursor-connection.md
+++ b/docs/rules/05-list/list-cursor-connection.md
@@ -1,7 +1,9 @@
 ---
 path: '/rules/list-cursor-connection'
-title: '5.5. For infinite lists (infinite scroll) use [Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm).'
+title: '5.5. For infinite lists (infinite scroll) use Relay Cursor Connections Specification.'
 ---
+
+[Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm)
 
 Pagination has a drawback. When items are adding or removing frequently, then when the user goes to the next page you may encounter problems:
 

--- a/docs/rules/06-mutations/README.md
+++ b/docs/rules/06-mutations/README.md
@@ -1,18 +1,18 @@
 ---
+pageType: section
 path: '/rules/mutation'
 title: '6. Mutation rules'
 ---
 
 No matter how many schemes I saw, most of the mess is in the Mutations. The following rules will allow you to make your API dry, clean and comfortable.
 
-- **6. Mutation rules**
-  - [6.1. Use Namespace-types to group mutations within a single resource.](./mutation-namespaces.md)
-  - [6.2. Go beyond CRUD – create small mutations for different business operations on resources.](./mutation-business-operations.md)
-  - [6.3. Consider the ability to perform mutations on multiple items (same type batch changes).](./mutation-batch-changes.md)
-  - [6.4. Mutations should clearly describe all the mandatory arguments, there should be no options either-either.](./mutation-required-args.md)
-  - [6.5. In mutations, put all variables into one unique input argument.](./mutation-input-arg.md)
-  - [6.6. Every mutation should have a unique payload type.](./mutation-payload.md)
-    - [6.6.1. In the mutation response, return the modified resource and its `id`.](./mutation-payload-record.md)
-    - [6.6.2. Return operation status in mutation response.](./mutation-payload-status.md)
-    - [6.6.3. In the mutation response, return a field of type `Query`.](./mutation-payload-query.md)
-    - [6.6.4. In the mutation response, return the `errors` field with typed user errors.](./mutation-payload-errors.md)
+- [6.1. Use Namespace-types to group mutations within a single resource.](./mutation-namespaces.md)
+- [6.2. Go beyond CRUD – create small mutations for different business operations on resources.](./mutation-business-operations.md)
+- [6.3. Consider the ability to perform mutations on multiple items (same type batch changes).](./mutation-batch-changes.md)
+- [6.4. Mutations should clearly describe all the mandatory arguments, there should be no options either-either.](./mutation-required-args.md)
+- [6.5. In mutations, put all variables into one unique input argument.](./mutation-input-arg.md)
+- [6.6. Every mutation should have a unique payload type.](./mutation-payload.md)
+  - [6.6.1. In the mutation response, return the modified resource and its `id`.](./mutation-payload-record.md)
+  - [6.6.2. Return operation status in mutation response.](./mutation-payload-status.md)
+  - [6.6.3. In the mutation response, return a field of type `Query`.](./mutation-payload-query.md)
+  - [6.6.4. In the mutation response, return the `errors` field with typed user errors.](./mutation-payload-errors.md)

--- a/docs/rules/06-mutations/README.md
+++ b/docs/rules/06-mutations/README.md
@@ -6,6 +6,8 @@ title: '6. Mutation rules'
 
 No matter how many schemes I saw, most of the mess is in the Mutations. The following rules will allow you to make your API dry, clean and comfortable.
 
+<!-- card-links -->
+
 - [6.1. Use Namespace-types to group mutations within a single resource.](./mutation-namespaces.md)
 - [6.2. Go beyond CRUD – create small mutations for different business operations on resources.](./mutation-business-operations.md)
 - [6.3. Consider the ability to perform mutations on multiple items (same type batch changes).](./mutation-batch-changes.md)

--- a/docs/rules/06-mutations/mutation-payload.md
+++ b/docs/rules/06-mutations/mutation-payload.md
@@ -1,4 +1,5 @@
 ---
+pageType: section
 path: '/rules/mutation-payload'
 title: '6.6. Every mutation should have a unique payload type.'
 ---
@@ -21,6 +22,8 @@ type Mutation {
 ```
 
 It is important to note that the fields returned in your Payload type must be nullable (optional). Т.е. if you will return an error, for example, in the field `userErrors`, then you can not guarantee the availability of data in the field `record`. This point may come up when clients will start asking you to make these fields mandatory, because static analysis forces them to do additional checks for data. You calmly have to tell them that they need to do the check, because the data may actually be missing.
+
+<!-- card-links -->
 
 - [6.6.1.](./mutation-payload-record.md) In the mutation response, return the modified resource and its `id`.
 - [6.6.2.](./mutation-payload-status.md) Return operation status in mutation response.

--- a/docs/rules/07-relations/README.md
+++ b/docs/rules/07-relations/README.md
@@ -1,9 +1,9 @@
 ---
+pageType: section
 path: '/rules/relations'
 title: '7. Rules of linkages between types (relationships)'
 ---
 
 The conceptual difference between GraphQL and REST API is that the implementation of the logic of obtaining related resources was transferred from the client to the server. While with REST API clients are wondering (without hypermedia) how to request related resources, writing a layer of gluing/pre-dragging data on the client. With GraphQL, people who perfectly understand their data domain are engaged in that business, and they do that much faster and more efficiently. Especially when the related resources are fetched within the server, the client does not spend a lot of time on long round-trips between the client and the server for subqueries. And you are not limited to 4 browser connections per domain since inside the server you can send at least 200 simultaneous requests if you have enough power.
 
-- **7. Rules of linkages between types (relationships)**
-  - [7.1. GraphQL schema should be "hairy"](./relations-hairy-graphql.md)
+- [7.1. GraphQL schema should be "hairy"](./relations-hairy-graphql.md)

--- a/docs/rules/07-relations/README.md
+++ b/docs/rules/07-relations/README.md
@@ -6,4 +6,6 @@ title: '7. Rules of linkages between types (relationships)'
 
 The conceptual difference between GraphQL and REST API is that the implementation of the logic of obtaining related resources was transferred from the client to the server. While with REST API clients are wondering (without hypermedia) how to request related resources, writing a layer of gluing/pre-dragging data on the client. With GraphQL, people who perfectly understand their data domain are engaged in that business, and they do that much faster and more efficiently. Especially when the related resources are fetched within the server, the client does not spend a lot of time on long round-trips between the client and the server for subqueries. And you are not limited to 4 browser connections per domain since inside the server you can send at least 200 simultaneous requests if you have enough power.
 
+<!-- card-links -->
+
 - [7.1. GraphQL schema should be "hairy"](./relations-hairy-graphql.md)

--- a/docs/rules/10-misc/README.md
+++ b/docs/rules/10-misc/README.md
@@ -6,4 +6,6 @@ title: '10. Other rules'
 
 ## 10. Other rules
 
+<!-- card-links -->
+
 - [10.1. Use markdown for documentation](./misc-docs-markdown.md)

--- a/docs/rules/10-misc/README.md
+++ b/docs/rules/10-misc/README.md
@@ -1,4 +1,5 @@
 ---
+pageType: section
 path: '/rules/misc'
 title: '10. Other rules'
 ---

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,4 +1,5 @@
 ---
+pageType: section
 path: '/rules'
 title: 'GraphQL-scheme design — make API comfortable, prevent pain and suffering'
 ---
@@ -9,30 +10,28 @@ This article could be changed in the future, cause current rules are advisory an
 
 If you think that any rule is a complete mess or it is not fully disclosed, or want to add your own – please open the [issue](https://github.com/graphql-rules/graphql-rules/issues). Errors and typos can be corrected via GitHub pull requests. I've only just started to make the rules, but to finish the job and stick it all together, only collaborative work can help us.
 
-## TL;DR of all rules
-
-- [**1. Naming rules**](./01-naming/README.md)
+- [1. Naming rules](./01-naming/README.md)
   - [1.1. Use `camelCase` for GraphQL-fields and arguments.](./01-naming/naming-fields-args.md)
   - [1.2. Use `UpperCamelCase` for GraphQL-types.](./01-naming/naming-types.md)
   - [1.3. Use `CAPITALIZED_WITH_UNDERSCORES` to name ENUM-types.](./01-naming/naming-enum.md)
-- [**2. Type rules**](./02-type/README.md)
+- [2. Type rules](./02-type/README.md)
   - [2.1. Use custom scalar types if you want to declare fields or args with specific semantic value.](./02-type/type-custom-scalars.md)
   - [2.2. Use Enum for fields which contain a specific set of values.](./02-type/type-enumerable.md)
-- [**3. Field Rules (Output)**](./03-fields-output/README.md)
+- [3. Field Rules (Output)](./03-fields-output/README.md)
   - [3.1. Use semantic names for fields and avoid leaking of implementation details in fields names.](./03-fields-output/output-semantic-names.md)
   - [3.2. Use `Non-Null` field if field will always have a given field value.](./03-fields-output/output-non-null.md)
   - [3.3. Group as many related fields into custom Object type as possible.](./03-fields-output/output-grouping.md)
-- [**4. Argument rules (Input)**](./04-fields-input/README.md)
+- [4. Argument rules (Input)](./04-fields-input/README.md)
   - [4.1. Group coupled arguments to the new input-type.](./04-fields-input/input-grouping.md)
   - [4.2.Use strict scalar types for arguments, eg. `DateTime` instead of `String`.](./04-fields-input/input-custom-scalar.md)
   - [4.3. Mark arguments as `required`, is they are required for query execution.](./04-fields-input/input-non-null.md)
-- [**5. Rules of lists**](./05-list/README.md)
+- [5. Rules of lists](./05-list/README.md)
   - [5.1. To filter the lists, use the `filter` argument, which contains all the available filters.](./05-list/list-filter.md)
   - [5.2. Use argument `sort` of type `Enum` or `[Enum!]` for listings sorting.](./05-list/list-sort.md)
   - [5.3. Use `limit` with default value and `skip` to limit number of returned items in list.](./05-list/list-limit-skip.md)
   - [5.4. Use `page`, `perPage` args for pagination and return output type with `items` (array of elements) and `pageInfo` (meta-data).](./05-list/list-pagination.md)
   - [5.5. For infinite lists (infinite scroll) use Relay Cursor Connections Specification.](./05-list/list-cursor-connection.md)
-- [**6. Mutation rules**](./06-mutations/README.md)
+- [6. Mutation rules](./06-mutations/README.md)
   - [6.1. Use Namespace-types to group mutations within a single resource.](./06-mutations/mutation-namespaces.md)
   - [6.2. Go beyond CRUD – create small mutations for different business operations on resources.](./06-mutations/mutation-business-operations.md)
   - [6.3. Consider the ability to perform mutations on multiple items (same type batch changes).](./06-mutations/mutation-batch-changes.md)
@@ -43,9 +42,9 @@ If you think that any rule is a complete mess or it is not fully disclosed, or w
     - [6.6.2. Return operation status in mutation response.](./06-mutations/mutation-payload-status.md)
     - [6.6.3. In the mutation response, return a field of type `Query`.](./06-mutations/mutation-payload-query.md)
     - [6.6.4. In the mutation response, return the `errors` field with typed user errors.](./06-mutations/mutation-payload-errors.md)
-- [**7. Rules of linkages between types (relationships)**](./07-relations/README.md)
+- [7. Rules of linkages between types (relationships)](./07-relations/README.md)
   - [7.1. GraphQL schema should be "hairy"](./07-relations/relations-hairy-graphql.md)
-- [**10. Other rules**](./10-misc/README.md)
+- [10. Other rules](./10-misc/README.md)
   - [10.1. Use markdown for documentation](./10-misc/misc-docs-markdown.md)
 - **A. Appendix**
   - [A-1 Useful links](./a-appendix/README.md#A-1)

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -10,6 +10,8 @@ This article could be changed in the future, cause current rules are advisory an
 
 If you think that any rule is a complete mess or it is not fully disclosed, or want to add your own – please open the [issue](https://github.com/graphql-rules/graphql-rules/issues). Errors and typos can be corrected via GitHub pull requests. I've only just started to make the rules, but to finish the job and stick it all together, only collaborative work can help us.
 
+<!-- card-links -->
+
 - [1. Naming rules](./01-naming/README.md)
   - [1.1. Use `camelCase` for GraphQL-fields and arguments.](./01-naming/naming-fields-args.md)
   - [1.2. Use `UpperCamelCase` for GraphQL-types.](./01-naming/naming-types.md)
@@ -46,6 +48,6 @@ If you think that any rule is a complete mess or it is not fully disclosed, or w
   - [7.1. GraphQL schema should be "hairy"](./07-relations/relations-hairy-graphql.md)
 - [10. Other rules](./10-misc/README.md)
   - [10.1. Use markdown for documentation](./10-misc/misc-docs-markdown.md)
-- **A. Appendix**
+- A. Appendix
   - [A-1 Useful links](./a-appendix/README.md#A-1)
 - [Credits](./CREDITS.md)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "react-helmet": "^5.2.1",
     "rehype-react": "^3.1.0",
     "styled-components": "^4.3.1",
-    "unist-util-find": "^1.0.1"
+    "unist-util-find": "^1.0.1",
+    "unist-util-map": "^1.0.5",
+    "unist-util-visit": "^1.4.1"
   },
   "devDependencies": {
     "@types/rehype-react": "^3.1.0",

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -9,8 +9,10 @@ const MenuItem = styled(Link)`
     'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   text-decoration: none;
   line-height: 1.5rem;
+  display: inline-block;
   letter-spacing: -0.0175rem;
   font-size: 0.875rem;
+  margin-bottom: 0.5rem;
 
   color: #333;
 

--- a/src/components/rule.tsx
+++ b/src/components/rule.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Link } from 'gatsby';
 import rehypeReact from 'rehype-react';
+import unistFind from 'unist-util-find';
 
 interface Props {
   ruleHtmlAst: string;
   title: string;
   mdPath?: string;
+  pageType?: string;
 }
 
 const Container = styled.div`
@@ -58,14 +61,101 @@ const Hairline = styled.div`
   margin: 32px 0px 16px 0px;
 `;
 
-const renderAst = new rehypeReact({
+const RulesList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  /* justify-content: center; */
+  /* background-color: greenyellow; */
+`;
+
+const RuleTile = styled.div`
+  width: 352px;
+  height: 80px;
+  /* background-color: red; */
+  margin: 0 24px 24px 0;
+  /* z-index: -1; hide shadow behind image */
+  box-shadow: 0px 2px 4px 0 rgba(0, 0, 0, 0.07), 0 0 26px -16px rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  display: flex;
+`;
+
+const RuleTileHeader = styled(Link)`
+  flex: 1;
+  margin: 16px 5px 0 64px;
+  text-overflow: ellipsis;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  letter-spacing: -0.01375rem;
+  color: rgba(135, 134, 131);
+  text-decoration: none;
+  text-overflow: ellipsis; /*Only works for 1 line http://hackingui.com/front-end/a-pure-css-solution-for-multiline-text-truncation/*/
+  /* Required for text-overflow to do anything */
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+const renderAst = (isSectionPage: boolean) =>
+  new rehypeReact({
+    createElement: React.createElement,
+    components: {
+      pre: ({ children }) => <Code>{children}</Code>,
+      ul: ({ children }) => {
+        return <>{isSectionPage ? null : children}</>;
+      },
+    },
+  }).Compiler;
+
+// Recursively search for the underlying string of list elements
+// typical structure <p></p>
+const findMenuTitle = (elements) => {
+  for (const elem of elements) {
+    if (elem && elem !== '\n') {
+      if (typeof elem === 'string') {
+        return elem;
+      }
+
+      const {
+        props: { children, href },
+      } = elem;
+
+      let res = findMenuTitle(children);
+      if (typeof res === 'string') {
+        // We need to return an array of children that contain text
+        // e.g. given a string "1.1 This is a `rule`" we will get an array
+        // ['1.1 This is a', { children: [...]]]
+        // so when we find a string we actually need to return a whole array that it belongs to
+        res = { children: children, mdPath: href };
+      }
+
+      if (res !== null) return res;
+    }
+  }
+
+  return null;
+};
+
+const renderMenuAst = new rehypeReact({
   createElement: React.createElement,
   components: {
-    pre: ({ children }) => <Code>{children}</Code>,
+    li: ({ children: elements }) => {
+      const { children, mdPath } = findMenuTitle(elements) || { children: [], mdPath: '' };
+      return (
+        <RuleTile>
+          <RuleTileHeader to={mdPath}>{children}</RuleTileHeader>
+        </RuleTile>
+      );
+    },
+    ul: ({ children }) => <RulesList>{children}</RulesList>,
   },
 }).Compiler;
 
-export default function Rule({ title, ruleHtmlAst, mdPath }: Props) {
+export default function Rule({ title, pageType, ruleHtmlAst, mdPath }: Props) {
+  const isSectionPage = pageType && pageType === 'section';
+  const menuItems = isSectionPage
+    ? unistFind(ruleHtmlAst, { type: 'element', tagName: 'ul' })
+    : null;
   return (
     <Container>
       <RuleContainer>
@@ -74,9 +164,10 @@ export default function Rule({ title, ruleHtmlAst, mdPath }: Props) {
           <RuleTitle>{title}</RuleTitle>
           <Hairline />
           <RuleDescription>
-            <div>{renderAst(ruleHtmlAst)}</div>
+            <div>{renderAst(isSectionPage)(ruleHtmlAst)}</div>
           </RuleDescription>
         </RuleBody>
+        {menuItems && <RulesList>{renderMenuAst(menuItems)}</RulesList>}
       </RuleContainer>
     </Container>
   );

--- a/src/components/rule.tsx
+++ b/src/components/rule.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'gatsby';
 import rehypeReact from 'rehype-react';
+import unistVisit from 'unist-util-visit';
+import unistMap from 'unist-util-map';
 import unistFind from 'unist-util-find';
 
 interface Props {
@@ -81,7 +83,7 @@ const RuleTile = styled.div`
 
 const RuleTileHeader = styled(Link)`
   flex: 1;
-  margin: 16px 5px 0 64px;
+  margin: 16px 5px 0 32px;
   text-overflow: ellipsis;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
     'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
@@ -92,58 +94,37 @@ const RuleTileHeader = styled(Link)`
   text-decoration: none;
   text-overflow: ellipsis; /*Only works for 1 line http://hackingui.com/front-end/a-pure-css-solution-for-multiline-text-truncation/*/
   /* Required for text-overflow to do anything */
-  white-space: nowrap;
+  /* white-space: nowrap; */
+  /* overflow: hidden; */
+
+  /* Fast fix for two lines with elipsis */
+  /* Does not work in FF */
+  display: -webkit-box;
+  height: 59.2px;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.625;
 `;
 
-const renderAst = (isSectionPage: boolean) =>
-  new rehypeReact({
-    createElement: React.createElement,
-    components: {
-      pre: ({ children }) => <Code>{children}</Code>,
-      ul: ({ children }) => {
-        return <>{isSectionPage ? null : children}</>;
-      },
-    },
-  }).Compiler;
-
-// Recursively search for the underlying string of list elements
-// typical structure <p></p>
-const findMenuTitle = (elements) => {
-  for (const elem of elements) {
-    if (elem && elem !== '\n') {
-      if (typeof elem === 'string') {
-        return elem;
-      }
-
-      const {
-        props: { children, href },
-      } = elem;
-
-      let res = findMenuTitle(children);
-      if (typeof res === 'string') {
-        // We need to return an array of children that contain text
-        // e.g. given a string "1.1 This is a `rule`" we will get an array
-        // ['1.1 This is a', { children: [...]]]
-        // so when we find a string we actually need to return a whole array that it belongs to
-        res = { children: children, mdPath: href };
-      }
-
-      if (res !== null) return res;
-    }
-  }
-
-  return null;
-};
-
-const renderMenuAst = new rehypeReact({
+const renderAst = new rehypeReact({
   createElement: React.createElement,
   components: {
-    li: ({ children: elements }) => {
-      const { children, mdPath } = findMenuTitle(elements) || { children: [], mdPath: '' };
+    pre: ({ children }) => <Code>{children}</Code>,
+  },
+}).Compiler;
+
+const renderCardLinksAst = new rehypeReact({
+  createElement: React.createElement,
+  components: {
+    li: (elements) => {
+      const { props }: any = unistFind(elements, { type: 'a' }) || {};
+      const { href, children }: any = props || {};
+      if (!href || !children) return null;
       return (
         <RuleTile>
-          <RuleTileHeader to={mdPath}>{children}</RuleTileHeader>
+          <RuleTileHeader to={href}>{children}</RuleTileHeader>
         </RuleTile>
       );
     },
@@ -151,11 +132,66 @@ const renderMenuAst = new rehypeReact({
   },
 }).Compiler;
 
+function cleanupListNode(ast: any) {
+  const children = [];
+  // travers only first level of children
+  // and pull out only first founded link
+  ast.children.forEach((childAst: any) => {
+    unistVisit(childAst, (node: any) => {
+      if (node.tagName === 'a') {
+        children.push({
+          tagName: 'li',
+          type: 'element',
+          properties: {},
+          children: [node],
+        });
+        return false;
+      }
+    });
+  });
+  return {
+    children,
+    tagName: 'ul',
+    type: 'element',
+    properties: {},
+  };
+}
+
+function pullOutCardLinks(ast: any): { ast: any; cardLinksAst: any } {
+  // clone ast via `unistMap` before modifying it
+  // otherwise when user returns back to the current page
+  // the modified ast will not contain card-links
+  const result = { ast: unistMap(ast, (n) => n), cardLinksAst: null };
+
+  let pullCardLinks = false;
+  unistVisit(result.ast, (node: any, index: number, parent: any) => {
+    // find comment <-- card-links --> in markdown
+    if (node.type === 'comment' && /card\-links/.test(node.value)) {
+      pullCardLinks = true;
+    }
+
+    // pull out first <ul> from ast after <-- card-links -->
+    if (pullCardLinks && node.tagName === 'ul') {
+      pullCardLinks = false;
+      parent.children.splice(index, 1);
+      result.cardLinksAst = cleanupListNode(node);
+    }
+  });
+
+  return result;
+}
+
 export default function Rule({ title, pageType, ruleHtmlAst, mdPath }: Props) {
   const isSectionPage = pageType && pageType === 'section';
-  const menuItems = isSectionPage
-    ? unistFind(ruleHtmlAst, { type: 'element', tagName: 'ul' })
-    : null;
+
+  let ast = ruleHtmlAst;
+  let cardLinksAst: any;
+  if (isSectionPage) {
+    const t = pullOutCardLinks(ruleHtmlAst);
+    ast = t.ast;
+    cardLinksAst = t.cardLinksAst;
+  }
+
   return (
     <Container>
       <RuleContainer>
@@ -164,10 +200,10 @@ export default function Rule({ title, pageType, ruleHtmlAst, mdPath }: Props) {
           <RuleTitle>{title}</RuleTitle>
           <Hairline />
           <RuleDescription>
-            <div>{renderAst(isSectionPage)(ruleHtmlAst)}</div>
+            <div>{renderAst(ast)}</div>
           </RuleDescription>
         </RuleBody>
-        {menuItems && <RulesList>{renderMenuAst(menuItems)}</RulesList>}
+        {cardLinksAst && renderCardLinksAst(cardLinksAst)}
       </RuleContainer>
     </Container>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,20 +6,28 @@ import SEO from '../components/seo';
 import Rule from '../components/rule';
 
 function IndexPage() {
-  const { markdownRemark } = useStaticQuery(
+  const {
+    markdownRemark: {
+      htmlAst,
+      frontmatter: { pageType },
+    },
+  } = useStaticQuery(
     graphql`
       query {
         markdownRemark(fileAbsolutePath: { glob: "**/rules/README.md" }) {
           htmlAst
+          frontmatter {
+            pageType
+          }
         }
       }
     `
   );
 
   return (
-    <Layout hideMenu>
+    <Layout>
       <SEO title="Home" />
-      <Rule ruleHtmlAst={markdownRemark.htmlAst} title={''} />
+      <Rule ruleHtmlAst={htmlAst} pageType={pageType} title={''} />
     </Layout>
   );
 }

--- a/src/templates/ruleTemplate.tsx
+++ b/src/templates/ruleTemplate.tsx
@@ -7,7 +7,11 @@ export default function Template({
   data, // this prop will be injected by the GraphQL query below.
 }) {
   const { markdownRemark } = data; // data.markdownRemark holds our post data
-  const { frontmatter, htmlAst, fileAbsolutePath = '' } = markdownRemark;
+  const {
+    frontmatter: { title, pageType },
+    htmlAst,
+    fileAbsolutePath = '',
+  } = markdownRemark;
 
   const mdPath = fileAbsolutePath.replace(
     /.*\/docs\/rules\/(.*)$/i,
@@ -16,7 +20,7 @@ export default function Template({
 
   return (
     <Layout>
-      <Rule mdPath={mdPath} ruleHtmlAst={htmlAst} title={frontmatter.title} />
+      <Rule mdPath={mdPath} ruleHtmlAst={htmlAst} title={title} pageType={pageType} />
     </Layout>
   );
 }
@@ -29,6 +33,7 @@ export const pageQuery = graphql`
       frontmatter {
         path
         title
+        pageType
       }
       fileAbsolutePath
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11132,6 +11132,13 @@ unist-util-is@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
 
+unist-util-map@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/unist-util-map/-/unist-util-map-1.0.5.tgz#701069b72e1d1cc02db265502a5e82b77c2eb8b7"
+  integrity sha512-dFil/AN6vqhnQWNCZk0GF/G3+Q5YwsB+PqjnzvpO2wzdRtUJ1E8PN+XRE/PRr/G3FzKjRTJU0haqE0Ekl+O3Ag==
+  dependencies:
+    object-assign "^4.0.1"
+
 unist-util-modify-children@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.4.tgz#f9dd31e93884c3be06b43c9291d60324d5df5f68"
@@ -11170,7 +11177,7 @@ unist-util-visit-parents@^2.0.0:
   dependencies:
     unist-util-is "^3.0.0"
 
-unist-util-visit@1.4.1, unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+unist-util-visit@1.4.1, unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.3.0, unist-util-visit@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
   dependencies:


### PR DESCRIPTION
Very limiting and error-prone implementation. I tried adding "pageType: section" to top-level README and section READMEs and then parsing "lists" in them and rendering as tiles.

This will break if:
- You have a list item in a top-level readme or section readme that is not a menu
- Your section starts with some style instead of plain text (e.g. the following list item will break`*1.4. This is my section*`)

Basically, this is only can be considered as a tmp solution. A proper solution would probably involve creating a JSON file with necessary meta information enough to create the desired tile-menus.