### PR TITLE
Provide strict return type for query example

### DIFF
--- a/docs/rules/04-fields-input/input-grouping.md
+++ b/docs/rules/04-fields-input/input-grouping.md
@@ -12,7 +12,7 @@ Instead of having arguments on the same level group them. For example, arguments
 
 ```graphql
 type Query {
-  articles(filter: ArticleFilter, limit: Int): [Article]
+  articles(filter: ArticleFilter, limit: Int): [Article!]!
 }
 
 input ArticleFilter {


### PR DESCRIPTION
To be in sync with field rules (output) https://graphql-rules.com/rules/output-non-null