### PR TITLE
Remove gender as an example of a finite set

### DIFF
--- a/docs/rules/02-type/type-enumerable.md
+++ b/docs/rules/02-type/type-enumerable.md
@@ -3,7 +3,7 @@ path: '/rules/type-enumerable'
 title: '2.2. Use Enum for fields that contain a fixed set of values.'
 ---
 
-A lot of times schemas include fields that represent a finite set of values. For example `gender`, `order status`, `country code`, `payment type`. Using a `String` or `Int` types doesn't help your consumers to understand which values may be received.
+A lot of times schemas include fields that represent a finite set of values. For example `order status`, `country code`, `payment type`. Using a `String` or `Int` types doesn't help your consumers to understand which values may be received.
 
 Of course, you can enumerate possible values in schema documentation but this is not advisable since GraphQL has a type `Enum`.
 


### PR DESCRIPTION
Fewer and fewer systems are using fixed enums to represent gender identity. We can be more inclusive by not using it as an example in the docs, and don't lose any useful context as the other examples are great by themselves.