### PR TITLE
docs: update 1.4 rule with consistent namings throughout examples

### DIFF
--- a/docs/rules/01-naming/naming-query-resolvers.md
+++ b/docs/rules/01-naming/naming-query-resolvers.md
@@ -14,12 +14,12 @@ query {
 }
 ```
 
-Frontend developers with the query above in their code will use it something like this (and it's obvious that `getlikeByUsers` looks a little bit awkward):
+Frontend developers with the query above in their code will use it something like this (and it's obvious that `getLikedByUsers` looks a little bit awkward):
 
 ```diff
 export function Example() {
   const { data } = useQuery();
--  return <div>{data.post.getlikeByUsers}</div>
-+  return <div>{data.post.likeByUsers}</div>
+-  return <div>{data.post.getLikedByUsers}</div>
++  return <div>{data.post.likedByUsers}</div>
 }
 ```


### PR DESCRIPTION
Hey @nodkz, this pull request adds consistency in namings at both examples for rule `1.4` at `1. Naming rules`. It looks like there was mistyping.

Closes #9 