### PR TITLE
Use interface instead of type for ClaimBase

### DIFF
--- a/docs/rules/03-fields-output/output-grouping.md
+++ b/docs/rules/03-fields-output/output-grouping.md
@@ -63,8 +63,8 @@ Now if `byPhone` isn't `null` then it surely contains a `phone` and `operatorCod
 If you are not familiar with [Union types](https://spec.graphql.org/June2018/#sec-Unions) you can think of them as "either A or B but not both".
 
 ```graphql
-# Basic type for complaint
-type ClaimBase {
+# Basic interface for complaint
+interface ClaimBase {
   text: String!
 }
 


### PR DESCRIPTION
I noticed that a `type` was being used as an interface. To my knowledge this is not possible in the current GraphQL spec.